### PR TITLE
Add support for using client count, and fixed input delay, for all inputs.

### DIFF
--- a/serverThread.cpp
+++ b/serverThread.cpp
@@ -2,17 +2,18 @@
 #include "udpServer.h"
 #include "tcpServer.h"
 
-ServerThread::ServerThread(int _port, QObject *parent)
+ServerThread::ServerThread(int _port, QObject *parent, bool _useClientCount)
     : QThread(parent)
 {
     registered = 0;
     port = _port;
+    useClientCount = _useClientCount;
 }
 
 void ServerThread::run()
 {
     char buffer_target = 2;
-    UdpServer udpServer(buffer_target);
+    UdpServer udpServer(buffer_target, useClientCount);
     TcpServer tcpServer(buffer_target);
     udpServer.setPort(port);
     tcpServer.setPort(port);

--- a/serverThread.h
+++ b/serverThread.h
@@ -7,7 +7,7 @@ class ServerThread : public QThread
     Q_OBJECT
     void run() Q_DECL_OVERRIDE;
 public:
-    ServerThread(int _port, QObject *parent = 0);
+    ServerThread(int _port, QObject *parent = 0, bool useClientCount = false);
 signals:
     void killServer(int port);
     void desynced(int port);
@@ -23,6 +23,7 @@ public slots:
 private:
     int port;
     int registered;
+    bool useClientCount;
 };
 
 #endif

--- a/serverThread.h
+++ b/serverThread.h
@@ -7,23 +7,25 @@ class ServerThread : public QThread
     Q_OBJECT
     void run() Q_DECL_OVERRIDE;
 public:
-    ServerThread(int _port, QObject *parent = 0, bool useClientCount = false);
+    ServerThread(int _port, QObject *parent = 0, int p1InputDelay = -1);
 signals:
     void killServer(int port);
     void desynced(int port);
     void sendClientNumber(int size);
     void writeLog(QString message, int port);
+    void inputDelayChanged(int playerNum, int inputDelay);
 private slots:
     void desync();
     void receiveLog(QString message, int _port);
     void player_registered(quint32 reg_id, quint8 playerNum, quint8 plugin);
     void shouldKill();
 public slots:
+    void setInputDelay(int playerNum, int delay);
     void getClientNumber(int _port, int size);
 private:
     int port;
     int registered;
-    bool useClientCount;
+    int p1InputDelay;
 };
 
 #endif

--- a/socketServer.cpp
+++ b/socketServer.cpp
@@ -205,9 +205,8 @@ void SocketServer::processBinaryMessage(QByteArray message)
             }
             clients[room_port].append(qMakePair(client, qMakePair(json.value("player_name").toString(), player_num)));
 
-            if (json.contains("input_delay")) {
+            if (json.contains("input_delay"))
                 emit inputDelayChanged(player_num - 1, json.value("input_delay").toInt());
-            }
         }
         room.remove("password");
         room.insert("player_name", json.value("player_name").toString());

--- a/socketServer.cpp
+++ b/socketServer.cpp
@@ -101,7 +101,8 @@ void SocketServer::processBinaryMessage(QByteArray message)
                     int lle = json.contains("lle") && json.value("lle").toString() == "Yes";
                     writeLog(QString("creating ") + (lle ? "LLE" : "HLE") + " room", json.value("room_name").toString(), json.value("game_name").toString(), port);
 
-                    ServerThread *serverThread = new ServerThread(port, this);
+                    bool useClientCount = json.contains("use_client_count") ? json.value("use_client_count").toBool() : false;
+                    ServerThread *serverThread = new ServerThread(port, this, useClientCount);
                     connect(serverThread, &ServerThread::writeLog, this, &SocketServer::receiveLog);
                     connect(serverThread, &ServerThread::killServer, this, &SocketServer::closeUdpServer);
                     connect(serverThread, &ServerThread::desynced, this, &SocketServer::desyncMessage);

--- a/socketServer.cpp
+++ b/socketServer.cpp
@@ -101,12 +101,14 @@ void SocketServer::processBinaryMessage(QByteArray message)
                     int lle = json.contains("lle") && json.value("lle").toString() == "Yes";
                     writeLog(QString("creating ") + (lle ? "LLE" : "HLE") + " room", json.value("room_name").toString(), json.value("game_name").toString(), port);
 
-                    bool useClientCount = json.contains("use_client_count") ? json.value("use_client_count").toBool() : false;
-                    ServerThread *serverThread = new ServerThread(port, this, useClientCount);
+                    int p1InputDelay = json.contains("input_delay") ? json.value("input_delay").toInt() : -1;
+
+                    ServerThread *serverThread = new ServerThread(port, this, p1InputDelay);
                     connect(serverThread, &ServerThread::writeLog, this, &SocketServer::receiveLog);
                     connect(serverThread, &ServerThread::killServer, this, &SocketServer::closeUdpServer);
                     connect(serverThread, &ServerThread::desynced, this, &SocketServer::desyncMessage);
                     connect(serverThread, &ServerThread::finished, serverThread, &ServerThread::deleteLater);
+                    connect(this, &SocketServer::inputDelayChanged, serverThread, &ServerThread::setInputDelay);
                     connect(this, &SocketServer::setClientNumber, serverThread, &ServerThread::getClientNumber);
                     serverThread->start();
                     room = json;
@@ -202,6 +204,10 @@ void SocketServer::processBinaryMessage(QByteArray message)
                 }
             }
             clients[room_port].append(qMakePair(client, qMakePair(json.value("player_name").toString(), player_num)));
+
+            if (json.contains("input_delay")) {
+                emit inputDelayChanged(player_num - 1, json.value("input_delay").toInt());
+            }
         }
         room.remove("password");
         room.insert("player_name", json.value("player_name").toString());

--- a/socketServer.h
+++ b/socketServer.h
@@ -24,6 +24,7 @@ public:
 signals:
     void closed();
     void setClientNumber(int room_port, int size);
+    void inputDelayChanged(int playerNum, int inputDelay);
 
 private slots:
     void onNewConnection();

--- a/udpServer.cpp
+++ b/udpServer.cpp
@@ -41,8 +41,6 @@ int UdpServer::getPort()
 void UdpServer::setInputDelay(int playerNum, int inputDelay)
 {
     input_delay[playerNum] = inputDelay;
-    if (inputDelay < 3)
-        buffer_size[playerNum] = inputDelay;
 }
 
 bool UdpServer::checkIfExists(quint8 playerNumber, quint32 count)
@@ -83,8 +81,8 @@ void UdpServer::sendInput(quint32 count, QHostAddress address, int port, quint8 
         curr += 4;
         if (!checkIfExists(playerNum, count))
         {
+            // we don't have an input for this frame yet
             end = count - 1;
-            // we don't have an input - the client must wait.
             continue;
         }
         qToBigEndian(inputs[playerNum].value(count).first, &buffer[curr]);

--- a/udpServer.cpp
+++ b/udpServer.cpp
@@ -113,7 +113,7 @@ void UdpServer::readPendingDatagrams()
                 keys = qFromBigEndian<quint32>(&incomingData.data()[6]);
                 if (input_delay[playerNum] >= 0) {
                     QPair<quint32, quint8> pair = qMakePair(keys, incomingData.at(10));
-                    inputs[playerNum].insert(count, pair);
+                    inputs[playerNum].insert(count + input_delay[playerNum], pair);
                     if (count == 0) {
                         // duplicate first client frame to cover input delay
                         for (int i = 0; i < input_delay[playerNum]; i++) {

--- a/udpServer.cpp
+++ b/udpServer.cpp
@@ -119,7 +119,10 @@ void UdpServer::readPendingDatagrams()
                 count = qFromBigEndian<quint32>(&incomingData.data()[2]);
                 keys = qFromBigEndian<quint32>(&incomingData.data()[6]);
                 if (input_delay[playerNum] >= 0)
-                    insertInput(playerNum, count + input_delay[playerNum], qMakePair(keys, incomingData.at(10)));
+                {
+                    QPair<quint32, quint8> pair = qMakePair(keys, incomingData.at(10));
+                    insertInput(playerNum, count + input_delay[playerNum], &pair);
+                }
                 else if (buttons[playerNum].size() == 0)
                     buttons[playerNum].append(qMakePair(keys, incomingData.at(10)));
                 break;
@@ -201,11 +204,11 @@ void UdpServer::disconnect_player(quint32 reg_id)
         emit killMe(port);
 }
 
-void UdpServer::insertInput(int playerNum, int count, QPair<quint32, quint8> pair)
+void UdpServer::insertInput(int playerNum, int count, QPair<quint32, quint8> *pair)
 {
     int previousCount = count - 1;
 
-    inputs[playerNum].insert(count, pair);
+    inputs[playerNum].insert(count, *pair);
 
     /* The recursion here covers two situations:
      *

--- a/udpServer.h
+++ b/udpServer.h
@@ -8,11 +8,12 @@ class UdpServer : public QObject
 {
     Q_OBJECT
 public:
-    UdpServer(char _buffer_target, bool _useClientCount);
+    UdpServer(char _buffer_target);
     void readPendingDatagrams();
     int getPort();
     void setPort(int _port);
     void close();
+    void setInputDelay(int playerNum, int inputDelay);
 protected:
     void timerEvent(QTimerEvent *te) Q_DECL_OVERRIDE;
 signals:
@@ -33,11 +34,11 @@ private:
     quint32 lead_count[4];
     quint8 buffer_size[4];
     int buffer_health[4];
+    int input_delay[4];
     int timerId;
     int port;
     quint8 status;
     char buffer_target;
-    bool useClientCount;
 };
 
 #endif

--- a/udpServer.h
+++ b/udpServer.h
@@ -26,7 +26,7 @@ public slots:
 private:
     void sendInput(quint32 count, QHostAddress address, int port, quint8 playerNum, quint8 spectator);
     bool checkIfExists(quint8 playerNumber, quint32 count);
-    void insertInput(int playerNum, int count, QPair<quint32, quint8> pair);
+    void insertInput(int playerNum, int count, QPair<quint32, quint8> *pair);
     QUdpSocket udpSocket;
     QHash<quint32, QPair<quint32, quint8>> inputs[4]; //<count, <BUTTONS, Plugin>>
     QHash<quint32, quint64> sync_hash; //cp0 hashes

--- a/udpServer.h
+++ b/udpServer.h
@@ -25,7 +25,8 @@ public slots:
     void disconnect_player(quint32 reg_id);
 private:
     void sendInput(quint32 count, QHostAddress address, int port, quint8 playerNum, quint8 spectator);
-    void checkIfExists(quint8 playerNumber, quint32 count);
+    bool checkIfExists(quint8 playerNumber, quint32 count);
+    void insertInput(int playerNum, int count, QPair<quint32, quint8> pair);
     QUdpSocket udpSocket;
     QHash<quint32, QPair<quint32, quint8>> inputs[4]; //<count, <BUTTONS, Plugin>>
     QHash<quint32, quint64> sync_hash; //cp0 hashes

--- a/udpServer.h
+++ b/udpServer.h
@@ -8,7 +8,7 @@ class UdpServer : public QObject
 {
     Q_OBJECT
 public:
-    UdpServer(char _buffer_target);
+    UdpServer(char _buffer_target, bool _useClientCount);
     void readPendingDatagrams();
     int getPort();
     void setPort(int _port);
@@ -37,6 +37,7 @@ private:
     int port;
     quint8 status;
     char buffer_target;
+    bool useClientCount;
 };
 
 #endif


### PR DESCRIPTION
The goal of the `use_client_count` option is to support only using the inputs sent by the client on the frame sent by the client, so that network latency doesn't change which frame an input occurs on.

I believe that this is the only change needed to ensure a consistent input delay (with the exception of lag) during netplay. From reading the code, I think that the `buffer_size` won't change which inputs are assigned to which frames, due to my changes in the checkifExists function. However, I'm not sure about that and gladly welcome your feedback.