### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: Build project
 permissions:
   contents: read
   actions: read
-  artifacts: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gopher64/gopher64-netplay-server/security/code-scanning/1](https://github.com/gopher64/gopher64-netplay-server/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are appropriate:
- `contents: read` for reading repository contents.
- `actions: read` for interacting with GitHub Actions.
- `artifacts: write` for uploading artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build` job. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
